### PR TITLE
Updated Sessionize API id for Global Azure Stockholm

### DIFF
--- a/2023/globalazurestockholm/data.json
+++ b/2023/globalazurestockholm/data.json
@@ -12,7 +12,7 @@
     "Name": "Global Azure Stockholm",
     "Country": "Sweden",
     "Url": "https://www.meetup.com/vasteras-azure-user-group/events/291645252/",
-    "SessionizeApiId": "92lir1p4",
+    "SessionizeApiId": "l7bcancn",
     "SessionizeEventName": "Global Azure Stockholm 2023",
     "Logo": {
       "Description": "Global Azure Stockholm 2023",


### PR DESCRIPTION
I accidentally changed the API endpoint for the event and got a new id, here's a change to update it for the global schedule site.